### PR TITLE
Added rate limiter .... and more suggestions

### DIFF
--- a/tile-manager.py
+++ b/tile-manager.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import math
+import time
 import argparse
 import requests
 import geopandas as gpd
@@ -85,6 +86,7 @@ def process_tiles(generate=False, request=False, max_downloads=0):
                             f.write(resp.content)
                         print(f" → Saved: {file_path}")
                         download_count += 1
+                        time.sleep(0.5) # make sure we don't go over the rate limit
                     except Exception as e:
                         print(f"Failed {url}: {e}")
                 else:

--- a/tile-manager.py
+++ b/tile-manager.py
@@ -86,9 +86,9 @@ def process_tiles(generate=False, request=False, max_downloads=0):
                             f.write(resp.content)
                         print(f" → Saved: {file_path}")
                         download_count += 1
-                        time.sleep(0.5) # make sure we don't go over the rate limit
                     except Exception as e:
                         print(f"Failed {url}: {e}")
+                    time.sleep(0.5) # make sure we don't go over the rate limit
                 else:
                     print(f"URL:  {url}?x-api-key={API_KEY}")
                     print(f"Path: {file_path}")


### PR DESCRIPTION
As per the documentation we received from howloud.com the API has a rate limit of three requests per second. To be careful the rate limiter in tile-manager.py is now set at two requests per second.

Also, two more suggestions:
- it would be great to have a README with a few examples of how to use the script
- it would be great to add the min and max zoom levels as options in the argument parser. Perhaps we could leave the defaults from 8-14 as is, but then be able to over-ride with an a set of command line arguments.